### PR TITLE
v2025.2.0a3 Fixed Python Encoder Module

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -353,7 +353,7 @@ if(IRIS_BUILD_PYTHON)
         # Copy install the python source files
         install(
             DIRECTORY ${PROJECT_SOURCE_DIR}/python/Iris/Encoder
-            DESTINATION ${IRIS_INSTALL_PYTHON_LIBDIR}/Iris/Encoder
+            DESTINATION ${IRIS_INSTALL_PYTHON_LIBDIR}/Iris/
         )
         # Then build the Python module
         pybind11_add_module(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "scikit_build_core.build"
 
 [project]
 name = "Iris-Codec" 
-version = "2025.2.0a2" 
+version = "2025.2.0a3" 
 
 description = "Portable and blazingly fast whole slide image compression and serialization library for the Iris File Extension"
 readme = "./python/README.md"


### PR DESCRIPTION
CMakeList.txt incorrectly installed the python source components of the python Encoder module in v2025.2.0a2. 