### PR TITLE
Update encoder for generated IFE headers

### DIFF
--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -54,6 +54,23 @@ jobs:
         python3-dev \
         meson ninja-build -y
     
+    - name: Check out Iris-File-Extension (this owner's fork if present, else upstream)
+      # FetchContent pulls IrisDigitalPathology/Iris-File-Extension by default;
+      # FETCHCONTENT_SOURCE_DIR_IRISFILEEXTENSION redirects it to this owner's
+      # fork when one exists, so a fork's CI tests the fork's IFE. The
+      # CMakeLists.txt probe makes a missing or empty fork fall back upstream.
+      shell: bash
+      run: |
+        if git clone --depth 1 "https://github.com/${{ github.repository_owner }}/Iris-File-Extension.git" "${RUNNER_TEMP}/ife" && \
+           [ -f "${RUNNER_TEMP}/ife/CMakeLists.txt" ]; then
+          echo "using ${{ github.repository_owner }}/Iris-File-Extension"
+        else
+          echo "no usable ${{ github.repository_owner }}/Iris-File-Extension" \
+               "(any clone error above is expected) - falling back to IrisDigitalPathology"
+          rm -rf "${RUNNER_TEMP}/ife"
+          git clone --depth 1 "https://github.com/IrisDigitalPathology/Iris-File-Extension.git" "${RUNNER_TEMP}/ife"
+        fi
+
     - name: Configure CMake
       run: >
         cmake -B ${{ steps.strings.outputs.build-output-dir }}
@@ -64,6 +81,7 @@ jobs:
         -D CMAKE_INSTALL_PREFIX=${{ steps.strings.outputs.install-dir }}
         -D CMAKE_PREFIX_PATH="$ENV{CMAKE_PREFIX_PATH};/opt/libjpeg-turbo/lib64/cmake/libjpeg-turbo/"
         -D TURBOJPEG_INCLUDE="/opt/libjpeg-turbo/include/"
+        -D FETCHCONTENT_SOURCE_DIR_IRISFILEEXTENSION="${{ runner.temp }}/ife"
         ${{ inputs.iris_cmake_flags }}
 
     - name: Build

--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -52,7 +52,15 @@ jobs:
         libavif-dev libpng-dev \
         zlib1g-dev openslide-tools \
         python3-dev \
-        meson ninja-build -y
+        meson ninja-build ccache -y
+
+    - name: Cache ccache
+      uses: actions/cache@v4
+      with:
+        path: ~/.cache/ccache
+        # ccache is content-addressed, so a static key is correct: restored
+        # objects hit only when the inputs are unchanged.
+        key: ccache-${{ runner.os }}
     
     - name: Check out Iris-File-Extension (this owner's fork if present, else upstream)
       # FetchContent pulls IrisDigitalPathology/Iris-File-Extension by default;
@@ -81,6 +89,7 @@ jobs:
         -D CMAKE_INSTALL_PREFIX=${{ steps.strings.outputs.install-dir }}
         -D CMAKE_PREFIX_PATH="$ENV{CMAKE_PREFIX_PATH};/opt/libjpeg-turbo/lib64/cmake/libjpeg-turbo/"
         -D TURBOJPEG_INCLUDE="/opt/libjpeg-turbo/include/"
+        -D CMAKE_CXX_COMPILER_LAUNCHER=ccache
         -D FETCHCONTENT_SOURCE_DIR_IRISFILEEXTENSION="${{ runner.temp }}/ife"
         ${{ inputs.iris_cmake_flags }}
 

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -33,12 +33,30 @@ jobs:
     - name: Fetch Dependencies
       run: brew install highway jpeg-turbo libavif openslide libpng meson ninja
 
+    - name: Check out Iris-File-Extension (this owner's fork if present, else upstream)
+      # FetchContent pulls IrisDigitalPathology/Iris-File-Extension by default;
+      # FETCHCONTENT_SOURCE_DIR_IRISFILEEXTENSION redirects it to this owner's
+      # fork when one exists, so a fork's CI tests the fork's IFE. The
+      # CMakeLists.txt probe makes a missing or empty fork fall back upstream.
+      shell: bash
+      run: |
+        if git clone --depth 1 "https://github.com/${{ github.repository_owner }}/Iris-File-Extension.git" "${RUNNER_TEMP}/ife" && \
+           [ -f "${RUNNER_TEMP}/ife/CMakeLists.txt" ]; then
+          echo "using ${{ github.repository_owner }}/Iris-File-Extension"
+        else
+          echo "no usable ${{ github.repository_owner }}/Iris-File-Extension" \
+               "(any clone error above is expected) - falling back to IrisDigitalPathology"
+          rm -rf "${RUNNER_TEMP}/ife"
+          git clone --depth 1 "https://github.com/IrisDigitalPathology/Iris-File-Extension.git" "${RUNNER_TEMP}/ife"
+        fi
+
     - name: Configure CMake
       run: >
         cmake -B ${{ steps.strings.outputs.build-output-dir }}
         -S ${{ github.workspace }}
         -D CMAKE_BUILD_TYPE=${{ inputs.build_type }}
         -D CMAKE_INSTALL_PREFIX=${{ steps.strings.outputs.install-dir }}
+        -D FETCHCONTENT_SOURCE_DIR_IRISFILEEXTENSION="${{ runner.temp }}/ife"
         ${{ inputs.iris_cmake_flags }}
 
     - name: Build

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -31,7 +31,15 @@ jobs:
         echo "install-dir=${{ github.workspace }}/${{ inputs.artifact }}" >> "$GITHUB_OUTPUT"
 
     - name: Fetch Dependencies
-      run: brew install highway jpeg-turbo libavif openslide libpng meson ninja
+      run: brew install highway jpeg-turbo libavif openslide libpng meson ninja ccache
+
+    - name: Cache ccache
+      uses: actions/cache@v4
+      with:
+        path: ~/Library/Caches/ccache
+        # ccache is content-addressed, so a static key is correct: restored
+        # objects hit only when the inputs are unchanged.
+        key: ccache-${{ runner.os }}
 
     - name: Check out Iris-File-Extension (this owner's fork if present, else upstream)
       # FetchContent pulls IrisDigitalPathology/Iris-File-Extension by default;
@@ -56,6 +64,7 @@ jobs:
         -S ${{ github.workspace }}
         -D CMAKE_BUILD_TYPE=${{ inputs.build_type }}
         -D CMAKE_INSTALL_PREFIX=${{ steps.strings.outputs.install-dir }}
+        -D CMAKE_CXX_COMPILER_LAUNCHER=ccache
         -D FETCHCONTENT_SOURCE_DIR_IRISFILEEXTENSION="${{ runner.temp }}/ife"
         ${{ inputs.iris_cmake_flags }}
 

--- a/.github/workflows/build-wasm.yml
+++ b/.github/workflows/build-wasm.yml
@@ -11,13 +11,25 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
 
+      - name: Cache Emscripten SDK
+        uses: actions/cache@v4
+        with:
+          path: ${{ github.workspace }}/emsdk
+          # 'latest' moves, so rotate the key daily and fall back to the
+          # previous day's install on a miss.
+          key: emsdk-${{ runner.os }}-${{ github.run_date }}
+          restore-keys: |
+            emsdk-${{ runner.os }}-
+
       - name: Setup Emscripten SDK
         run: |
-          git clone https://github.com/emscripten-core/emsdk.git \
-            ${{ github.workspace }}/emsdk
-          cd ${{ github.workspace }}/emsdk
-          git pull
-          ./emsdk  install latest
+          if [ ! -x "${{ github.workspace }}/emsdk/emsdk" ]; then
+            git clone https://github.com/emscripten-core/emsdk.git \
+              "${{ github.workspace }}/emsdk"
+            cd "${{ github.workspace }}/emsdk"
+            ./emsdk install latest
+          fi
+          cd "${{ github.workspace }}/emsdk"
           ./emsdk activate latest
         shell: bash
 

--- a/.github/workflows/build-wasm.yml
+++ b/.github/workflows/build-wasm.yml
@@ -21,11 +21,28 @@ jobs:
           ./emsdk activate latest
         shell: bash
 
+      - name: Check out Iris-File-Extension (this owner's fork if present, else upstream)
+        # FetchContent pulls IrisDigitalPathology/Iris-File-Extension by default;
+        # FETCHCONTENT_SOURCE_DIR_IRISFILEEXTENSION redirects it to this owner's
+        # fork when one exists, so a fork's CI tests the fork's IFE. The
+        # CMakeLists.txt probe makes a missing or empty fork fall back upstream.
+        shell: bash
+        run: |
+          if git clone --depth 1 "https://github.com/${{ github.repository_owner }}/Iris-File-Extension.git" "${RUNNER_TEMP}/ife" && \
+             [ -f "${RUNNER_TEMP}/ife/CMakeLists.txt" ]; then
+            echo "using ${{ github.repository_owner }}/Iris-File-Extension"
+          else
+            echo "no usable ${{ github.repository_owner }}/Iris-File-Extension" \
+                 "(any clone error above is expected) - falling back to IrisDigitalPathology"
+            rm -rf "${RUNNER_TEMP}/ife"
+            git clone --depth 1 "https://github.com/IrisDigitalPathology/Iris-File-Extension.git" "${RUNNER_TEMP}/ife"
+          fi
+
       - name: Configure & Build
         working-directory: javascript
         run: |
           source ${{ github.workspace }}/emsdk/emsdk_env.sh
-          emcmake cmake -B build -DCMAKE_INSTALL_PREFIX=install .
+          emcmake cmake -B build -DCMAKE_INSTALL_PREFIX=install -D FETCHCONTENT_SOURCE_DIR_IRISFILEEXTENSION="${{ runner.temp }}/ife" .
           cmake --build build --config Release -j$CPU_COUNT
           cmake --install build
         shell: bash

--- a/.github/workflows/build-win.yml
+++ b/.github/workflows/build-win.yml
@@ -45,11 +45,21 @@ jobs:
           core.exportVariable('ACTIONS_CACHE_URL', process.env.ACTIONS_CACHE_URL || '');
           core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN || '');
           
+    - name: Cache Vcpkg
+      uses: actions/cache@v4
+      with:
+        path: ${{ github.workspace }}/vcpkg
+        key: vcpkg-${{ runner.os }}-x64
+
     - name: Configure Vcpkg
-      run: >
-        git clone --depth 1 https://github.com/microsoft/vcpkg.git ${{ github.workspace }}\vcpkg && 
-        ${{ github.workspace }}\vcpkg\bootstrap-vcpkg.bat &&
-        ${{ github.workspace }}\vcpkg\vcpkg.exe install highway libjpeg-turbo libavif libpng --binarysource="clear;x-gha,readwrite"
+      run: |
+        if (-not (Test-Path "${{ github.workspace }}\vcpkg\vcpkg.exe")) {
+          git clone --depth 1 https://github.com/microsoft/vcpkg.git "${{ github.workspace }}\vcpkg"
+          & "${{ github.workspace }}\vcpkg\bootstrap-vcpkg.bat"
+        }
+        # Package binaries come from the x-gha binary cache below; only the
+        # clone and bootstrap are what the directory cache above avoids.
+        & "${{ github.workspace }}\vcpkg\vcpkg.exe" install highway libjpeg-turbo libavif libpng --binarysource="clear;x-gha,readwrite"
 
     - name: Install Meson
       run: |

--- a/.github/workflows/build-win.yml
+++ b/.github/workflows/build-win.yml
@@ -56,6 +56,23 @@ jobs:
         python -m pip install --upgrade pip
         pip install meson ninja
         
+    - name: Check out Iris-File-Extension (this owner's fork if present, else upstream)
+      # FetchContent pulls IrisDigitalPathology/Iris-File-Extension by default;
+      # FETCHCONTENT_SOURCE_DIR_IRISFILEEXTENSION redirects it to this owner's
+      # fork when one exists, so a fork's CI tests the fork's IFE. The
+      # CMakeLists.txt probe makes a missing or empty fork fall back upstream.
+      shell: bash
+      run: |
+        if git clone --depth 1 "https://github.com/${{ github.repository_owner }}/Iris-File-Extension.git" "${RUNNER_TEMP}/ife" && \
+           [ -f "${RUNNER_TEMP}/ife/CMakeLists.txt" ]; then
+          echo "using ${{ github.repository_owner }}/Iris-File-Extension"
+        else
+          echo "no usable ${{ github.repository_owner }}/Iris-File-Extension" \
+               "(any clone error above is expected) - falling back to IrisDigitalPathology"
+          rm -rf "${RUNNER_TEMP}/ife"
+          git clone --depth 1 "https://github.com/IrisDigitalPathology/Iris-File-Extension.git" "${RUNNER_TEMP}/ife"
+        fi
+
     - name: Configure CMake
       run: >
         cmake -GNinja -B ${{ steps.strings.outputs.build-output-dir }}
@@ -65,6 +82,7 @@ jobs:
         -D CMAKE_BUILD_TYPE=${{ inputs.build_type }}
         -D CMAKE_INSTALL_PREFIX=${{ steps.strings.outputs.install-dir }}
         -D CMAKE_PREFIX_PATH="$ENV{CMAKE_PREFIX_PATH};${{ github.workspace }}/vcpkg/installed/x64-windows"
+        -D FETCHCONTENT_SOURCE_DIR_IRISFILEEXTENSION="${{ runner.temp }}/ife"
         ${{ inputs.iris_cmake_flags }}
 
     - name: Build 

--- a/.github/workflows/cmake-macos-CI.yml
+++ b/.github/workflows/cmake-macos-CI.yml
@@ -18,15 +18,12 @@ jobs:
       fail-fast: false
       
       matrix:
-        os: [macos-latest, macos-13]
+        os: [macos-latest]
         build_type: [Release]
         include:
           - os: macos-latest
             name: macos
             arch: arm64
-          - os: macos-13
-            name: macos
-            arch: x86_64
 
     uses: ./.github/workflows/build-macos.yml
     with:

--- a/.github/workflows/distribute-pypi.yml
+++ b/.github/workflows/distribute-pypi.yml
@@ -58,7 +58,26 @@ jobs:
                 python -m pip install --upgrade pip 
                 pip install build scikit-build-core meson ninja setuptools-scm
 
+          - name: Check out Iris-File-Extension (this owner's fork if present, else upstream)
+            # Same per-owner resolution as the reusable build workflows: the
+            # python module compiles against the fetched IFE, and the org's
+            # main still carries the pre-move layout without
+            # include/IrisFileExtension.hpp.
+            shell: bash
+            run: |
+                if git clone --depth 1 "https://github.com/${{ github.repository_owner }}/Iris-File-Extension.git" "${RUNNER_TEMP}/ife" && \
+                   [ -f "${RUNNER_TEMP}/ife/CMakeLists.txt" ]; then
+                  echo "using ${{ github.repository_owner }}/Iris-File-Extension"
+                else
+                  rm -rf "${RUNNER_TEMP}/ife"
+                  git clone --depth 1 "https://github.com/IrisDigitalPathology/Iris-File-Extension.git" "${RUNNER_TEMP}/ife"
+                fi
+
           - name: Build Self-contained Python Module
+            env:
+                # scikit-build-core honours CMAKE_ARGS, the standard pip
+                # convention, and passes it to the CMake configure.
+                CMAKE_ARGS: -DFETCHCONTENT_SOURCE_DIR_IRISFILEEXTENSION=${{ runner.temp }}/ife
             shell: bash
             run: |
                 if [ "${{ github.event_name }}" == "release" ]; then
@@ -93,6 +112,21 @@ jobs:
                 python -m pip install --upgrade pip 
                 pip install scikit-build-core uv cibuildwheel setuptools-scm
 
+          - name: Check out Iris-File-Extension (this owner's fork if present, else upstream)
+            # Same per-owner resolution as the reusable build workflows. The
+            # clone lives inside the workspace because cibuildwheel mounts the
+            # project into the container, so /project/ife-checkout resolves
+            # there.
+            shell: bash
+            run: |
+                if git clone --depth 1 "https://github.com/${{ github.repository_owner }}/Iris-File-Extension.git" "${{ github.workspace }}/ife-checkout" && \
+                   [ -f "${{ github.workspace }}/ife-checkout/CMakeLists.txt" ]; then
+                  echo "using ${{ github.repository_owner }}/Iris-File-Extension"
+                else
+                  rm -rf "${{ github.workspace }}/ife-checkout"
+                  git clone --depth 1 "https://github.com/IrisDigitalPathology/Iris-File-Extension.git" "${{ github.workspace }}/ife-checkout"
+                fi
+
           - name: Build Self-contained Python Module
             env:
                 CIBW_BUILD: "${{ matrix.python }}-*"
@@ -103,6 +137,7 @@ jobs:
                 CIBW_MANYLINUX_PYPY_X86_64_IMAGE: quay.io/pypa/manylinux_2_34_x86_64
                 CIBW_MANYLINUX_PYPY_AARCH64_IMAGE: quay.io/pypa/manylinux_2_34_aarch64
                 CIBW_REPAIR_WHEEL_COMMAND_LINUX: "auditwheel repair -w {dest_dir} {wheel} --exclude libopenslide.so.*"
+                CIBW_ENVIRONMENT: "CMAKE_ARGS=-DFETCHCONTENT_SOURCE_DIR_IRISFILEEXTENSION=/project/ife-checkout"
             shell: bash
             run: |
                 if [ "${{ github.event_name }}" == "release" ]; then

--- a/.github/workflows/distribute-pypi.yml
+++ b/.github/workflows/distribute-pypi.yml
@@ -43,7 +43,7 @@ jobs:
     strategy: 
       fail-fast: false
       matrix:
-        os: [macos-latest, macos-13, windows-latest]
+        os: [macos-latest, windows-latest]
         python: ['3.11','3.12','3.13']
     steps:
           - uses: actions/checkout@v4

--- a/.github/workflows/distribute-pypi.yml
+++ b/.github/workflows/distribute-pypi.yml
@@ -63,6 +63,12 @@ jobs:
             # python module compiles against the fetched IFE, and the org's
             # main still carries the pre-move layout without
             # include/IrisFileExtension.hpp.
+            #
+            # IFE_FETCH_DIR is emitted in forward-slash form: CMAKE_ARGS goes
+            # through an escape-aware parse (shlex) on its way to CMake, which
+            # eats the backslashes of a native Windows path (D:\a\_temp became
+            # D:/a_temp and the source dir vanished). cygpath -m is Git Bash's
+            # forward-slash path conversion.
             shell: bash
             run: |
                 if git clone --depth 1 "https://github.com/${{ github.repository_owner }}/Iris-File-Extension.git" "${RUNNER_TEMP}/ife" && \
@@ -72,12 +78,17 @@ jobs:
                   rm -rf "${RUNNER_TEMP}/ife"
                   git clone --depth 1 "https://github.com/IrisDigitalPathology/Iris-File-Extension.git" "${RUNNER_TEMP}/ife"
                 fi
+                if command -v cygpath >/dev/null; then
+                  echo "IFE_FETCH_DIR=$(cygpath -m "${RUNNER_TEMP}")/ife" >> "$GITHUB_ENV"
+                else
+                  echo "IFE_FETCH_DIR=${RUNNER_TEMP}/ife" >> "$GITHUB_ENV"
+                fi
 
           - name: Build Self-contained Python Module
             env:
                 # scikit-build-core honours CMAKE_ARGS, the standard pip
                 # convention, and passes it to the CMake configure.
-                CMAKE_ARGS: -DFETCHCONTENT_SOURCE_DIR_IRISFILEEXTENSION=${{ runner.temp }}/ife
+                CMAKE_ARGS: -DFETCHCONTENT_SOURCE_DIR_IRISFILEEXTENSION=${{ env.IFE_FETCH_DIR }}
             shell: bash
             run: |
                 if [ "${{ github.event_name }}" == "release" ]; then

--- a/.github/workflows/distribute-releases.yml
+++ b/.github/workflows/distribute-releases.yml
@@ -47,15 +47,12 @@ jobs:
       fail-fast: true
 
       matrix:
-        os: [macos-latest, macos-13]
+        os: [macos-latest]
         build_type: [Release]
         include:
           - os: macos-latest
             name: macos
             arch: arm64
-          - os: macos-13
-            name: macos
-            arch: x86_64
 
     uses: ./.github/workflows/build-macos.yml
     with:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -145,7 +145,7 @@ endif(IRIS_BUILD_ENCODER)
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 # Iris Codec Universal Object Build
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-set(IFE_SOURCE_DIR ${irisfileextension_SOURCE_DIR}/src)
+set(IFE_SOURCE_DIR ${irisfileextension_SOURCE_DIR}/include)
 set(CODEC_SOURCE_DIR ${PROJECT_SOURCE_DIR}/src)
 set (
     IrisCodecSources
@@ -166,6 +166,10 @@ set (
     IrisCodecInclude
     ${CODEC_SOURCE_DIR}
     ${IFE_SOURCE_DIR}
+    # IFE's generated layer: the public umbrella includes IFE_Blocks.hpp and
+    # friends from generated_source/, which is not part of the include/
+    # layout — it is generated at IFE configure time.
+    ${irisfileextension_SOURCE_DIR}/generated_source
     ${glm_SOURCE_DIR}
     ${irisheaders_SOURCE_DIR}/priv
     ${vkmemoryallocator_SOURCE_DIR}/include

--- a/javascript/CMakeLists.txt
+++ b/javascript/CMakeLists.txt
@@ -88,7 +88,7 @@ message(STATUS "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 # Iris Codec Universal Object Build
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-set(IFE_SOURCE_DIR ${irisfileextension_SOURCE_DIR}/src)
+set(IFE_SOURCE_DIR ${irisfileextension_SOURCE_DIR}/include)
 add_executable(
     iris-codec
     $<TARGET_OBJECTS:IrisFileExtensionLib>
@@ -98,7 +98,10 @@ target_include_directories (
     iris-codec PRIVATE 
     ${irisheaders_SOURCE_DIR}/include
     ${irisheaders_SOURCE_DIR}/priv
-    ${IFE_SOURCE_DIR} 
+    ${IFE_SOURCE_DIR}
+    # The generated layer lives outside include/ and is generated at IFE
+    # configure time; the root CMakeLists carries the same two directories.
+    ${irisfileextension_SOURCE_DIR}/generated_source
 )
 if (CMAKE_BUILD_TYPE STREQUAL "Debug")
     target_link_options(

--- a/javascript/IrisCodecJavascript.cpp
+++ b/javascript/IrisCodecJavascript.cpp
@@ -18,6 +18,9 @@
 #include <emscripten/val.h>
 #include <string>
 #include <iostream>
+#include <algorithm>
+#include <cstdint>
+#include <vector>
 #include <sstream>
 #include <map>
 #include <set>
@@ -277,6 +280,73 @@ public:
         }
     }
 };
+/// Fetch the structural prefix of a hosted slide and shallow-validate it.
+///
+/// The generated runtime is bytes-only: validate_file_structure and
+/// abstract_file_structure take a flat buffer, and a hosted file is never
+/// fully resident. This fetches just the five blocks the abstraction requires
+/// (FILE_HEADER, TILE_TABLE, LAYER_EXTENTS, TILE_OFFSETS, METADATA) through
+/// IFE's own windowed fetch -- Window::remote + fetch_http_range, the same
+/// ranged transport v1 used, with the caching and bounds logic tested
+/// natively on IFE's side. The encoder lays every optional block after
+/// metadata, so their handles fall outside the prefix and the abstraction
+/// skips them; the Slide needs the tile table and metadata only.
+///
+/// On success `out` holds the prefix and `out_version` the file's declared
+/// version; returns false when a range could not be fetched.
+bool fetch_structural_prefix(const std::string& url, size_t file_size,
+                             std::vector<IFE::BYTE>& out, uint32_t& out_version) {
+    IFE::Window window = IFE::Window::remote(
+        static_cast<IFE::Size>(file_size), IFE::fetch_http_range,
+        const_cast<char*>(url.c_str()));
+
+    // Bootstrap the version the way the runtime does: every gate open for one
+    // block, then rebuild at the version the file declares.
+    const IFE::BYTE* header_page = window.map(0, Serialization::FILE_HEADER::header_size);
+    if (!header_page) return false;
+    const Serialization::FILE_HEADER bootstrap{
+        header_page, 0, static_cast<IFE::Size>(file_size), UINT32_MAX};
+    out_version = (static_cast<uint32_t>(bootstrap.extension_major()) << 16)
+                | bootstrap.extension_minor();
+
+    const IFE::BYTE* table_page = window.map(
+        bootstrap.tile_table_offset().__offset, Serialization::TILE_TABLE::header_size);
+    if (!table_page) return false;
+    const Serialization::TILE_TABLE table{
+        table_page, 0, static_cast<IFE::Size>(file_size), out_version};
+
+    const IFE::Offset extents_off  = table.layer_extents_offset().__offset;
+    const IFE::Offset offsets_off  = table.tile_offsets_offset().__offset;
+    const IFE::Offset metadata_off = bootstrap.metadata_offset().__offset;
+
+    // The counts size the two array blocks; each block's header page is
+    // enough to read its count.
+    const IFE::BYTE* extents_page = window.map(extents_off, Serialization::LAYER_EXTENTS::header_size);
+    const IFE::BYTE* offsets_page = window.map(offsets_off, Serialization::TILE_OFFSETS::header_size);
+    if (!extents_page || !offsets_page) return false;
+    const Serialization::LAYER_EXTENTS extents{
+        extents_page, 0, static_cast<IFE::Size>(file_size), out_version};
+    const Serialization::TILE_OFFSETS offsets{
+        offsets_page, 0, static_cast<IFE::Size>(file_size), out_version};
+
+    const IFE::Size prefix_end = std::max({
+        metadata_off + Serialization::METADATA::header_size,
+        extents_off + Serialization::LAYER_EXTENTS::header_size
+                    + static_cast<IFE::Size>(extents.count())
+                        * Serialization::LAYER_EXTENTS::LAYER_EXTENT::entry_size,
+        offsets_off + Serialization::TILE_OFFSETS::header_size
+                    + static_cast<IFE::Size>(offsets.count())
+                        * Serialization::TILE_OFFSETS::TILE_OFFSET::entry_size,
+    });
+
+    // One contiguous page covering the whole structural region; copied out
+    // because the Window owns the page and dies with this function.
+    const IFE::BYTE* prefix = window.map(0, prefix_end);
+    if (!prefix) return false;
+    out.assign(prefix, prefix + prefix_end);
+    return true;
+}
+
 emscripten::val _validateFileStructure(const std::string& url) {
     size_t file_size = get_file_size_async(url.c_str());
     if (file_size < Serialization::FILE_HEADER::header_size)
@@ -291,7 +361,41 @@ emscripten::val _validateFileStructure(const std::string& url) {
         (Result(Iris::IRIS_FAILURE,
         "The server hosting the slide file does not support Ranged Reads."));
     }
-    return emscripten::val(validate_file_structure(url, file_size));
+
+    std::vector<IFE::BYTE> prefix;
+    uint32_t version = 0;
+    if (!fetch_structural_prefix(url, file_size, prefix, version))
+        return emscripten::val
+        (Result(Iris::IRIS_FAILURE,
+        "Failed to fetch the hosted file's structural blocks from the remote endpoint."));
+
+    // Shallow structural validation over the prefix: the five blocks the
+    // abstraction requires, bounded by the full file size so tile data
+    // offsets -- which point past the prefix -- still validate. The tiles
+    // themselves are fetched on demand and validated at decode time.
+    const Serialization::FILE_HEADER header{
+        prefix.data(), 0, static_cast<IFE::Size>(file_size), version};
+    if (!header.validate())
+        return emscripten::val(Result(Iris::IRIS_VALIDATION_FAILURE,
+        "The hosted file's header failed validation."));
+    const auto table = header.tile_table_offset();
+    if (!table.validate())
+        return emscripten::val(Result(Iris::IRIS_VALIDATION_FAILURE,
+        "The hosted file's tile table failed validation."));
+    const auto extents = table.layer_extents_offset();
+    if (!extents.validate())
+        return emscripten::val(Result(Iris::IRIS_VALIDATION_FAILURE,
+        "The hosted file's layer extents failed validation."));
+    const auto offsets = table.tile_offsets_offset();
+    if (!offsets.validate())
+        return emscripten::val(Result(Iris::IRIS_VALIDATION_FAILURE,
+        "The hosted file's tile offsets failed validation."));
+    const auto metadata = header.metadata_offset();
+    if (!metadata.validate())
+        return emscripten::val(Result(Iris::IRIS_VALIDATION_FAILURE,
+        "The hosted file's metadata block failed validation."));
+
+    return emscripten::val(Result(Iris::IRIS_SUCCESS, ""));
 }
 emscripten::val _openSlide(const std::string& url) {
     size_t file_size = get_file_size_async(url.c_str());
@@ -299,7 +403,13 @@ emscripten::val _openSlide(const std::string& url) {
         return emscripten::val();
     if (!confirm_range_support(url.c_str(), Serialization::FILE_HEADER::header_size))
         return emscripten::val();
-    auto file = abstract_file_structure(url, file_size);
+
+    std::vector<IFE::BYTE> prefix;
+    uint32_t version = 0;
+    if (!fetch_structural_prefix(url, file_size, prefix, version))
+        throw std::runtime_error
+        ("Failed to fetch the hosted file's structural blocks from remote endpoint ("+url+")");
+    auto file = abstract_file_structure(prefix.data(), prefix.size());
     return emscripten::val(std::make_shared<__INTERNAL__Slide>(url,file));
 }
 } // END IRIS_CODEC

--- a/javascript/IrisCodecJavascript.cpp
+++ b/javascript/IrisCodecJavascript.cpp
@@ -409,7 +409,7 @@ emscripten::val _openSlide(const std::string& url) {
     if (!fetch_structural_prefix(url, file_size, prefix, version))
         throw std::runtime_error
         ("Failed to fetch the hosted file's structural blocks from remote endpoint ("+url+")");
-    auto file = abstract_file_structure(prefix.data(), prefix.size());
+    auto file = abstract_file_structure({prefix.data(), prefix.size()});
     return emscripten::val(std::make_shared<__INTERNAL__Slide>(url,file));
 }
 } // END IRIS_CODEC

--- a/javascript/IrisCodecJavascript.cpp
+++ b/javascript/IrisCodecJavascript.cpp
@@ -279,13 +279,13 @@ public:
 };
 emscripten::val _validateFileStructure(const std::string& url) {
     size_t file_size = get_file_size_async(url.c_str());
-    if (file_size < Serialization::FILE_HEADER::HEADER_SIZE)
+    if (file_size < Serialization::FILE_HEADER::header_size)
     {
         return emscripten::val
         (Result(Iris::IRIS_VALIDATION_FAILURE,
         "The hosted file is not an Iris slide file."));
     }
-    if (!confirm_range_support(url.c_str(), Serialization::FILE_HEADER::HEADER_SIZE))
+    if (!confirm_range_support(url.c_str(), Serialization::FILE_HEADER::header_size))
     {
         return emscripten::val
         (Result(Iris::IRIS_FAILURE,
@@ -295,9 +295,9 @@ emscripten::val _validateFileStructure(const std::string& url) {
 }
 emscripten::val _openSlide(const std::string& url) {
     size_t file_size = get_file_size_async(url.c_str());
-    if (file_size < Serialization::FILE_HEADER::HEADER_SIZE)
+    if (file_size < Serialization::FILE_HEADER::header_size)
         return emscripten::val();
-    if (!confirm_range_support(url.c_str(), Serialization::FILE_HEADER::HEADER_SIZE))
+    if (!confirm_range_support(url.c_str(), Serialization::FILE_HEADER::header_size))
         return emscripten::val();
     auto file = abstract_file_structure(url, file_size);
     return emscripten::val(std::make_shared<__INTERNAL__Slide>(url,file));

--- a/src/IrisCodecEncoder.cpp
+++ b/src/IrisCodecEncoder.cpp
@@ -5,13 +5,53 @@
 //  Created by Ryan Landvater on 8/2/22.
 //
 #include <cmath>
+#include <cstring>
 #include <filesystem>
+#include <vector>
 #include "IrisCodecPriv.hpp"
 
 // TODO: Make max pending memory a runtime configurable
 constexpr size_t MAX_MEMORY_PRESSURE = 2E9; // 2 GB
 
 namespace IrisCodec {
+// The generated consumer API (IFE_Serialization.hpp): one namespace for the
+// whole write surface. Brought in so the retired bare sentinels (NULL_OFFSET)
+// keep resolving; the writers below are migrated to its store()/size_of().
+using namespace Serialization;
+
+// The generated writers report failures as a Status; this encoder's contract
+// is exceptions, so convert at the API boundary.
+[[noreturn]] inline void THROW_IF_FAILED (const Status& status, const char* what) {
+    throw std::runtime_error(std::string(what) + " failed: " +
+                             status.block + "." + status.field + " (check code " +
+                             std::to_string(static_cast<int>(status.code)) + ")");
+}
+
+// The generated layer's ImageEntry.ORIENTATION is the decoded float; the
+// codec's ImageOrientation enum carries IEEE binary16 bits. Decode.
+inline float HALF_TO_FLOAT (const uint16_t half) noexcept {
+    const uint32_t sign = uint32_t(half & 0x8000u) << 16;
+    const uint32_t exp  = (half >> 10) & 0x1Fu;
+    const uint32_t man  = half & 0x3FFu;
+    uint32_t bits;
+    if (exp == 0) {
+        if (man == 0) bits = sign;
+        else {
+            int e = -1;
+            uint32_t m = man;
+            do { ++e; m <<= 1; } while ((m & 0x400u) == 0);
+            bits = sign | uint32_t(127 - 15 - e) << 23 | (m & 0x3FFu) << 13;
+        }
+    } else if (exp == 0x1Fu) {
+        bits = sign | 0x7F800000u | (man << 13);
+    } else {
+        bits = sign | uint32_t(exp - 15 + 127) << 23 | (man << 13);
+    }
+    float out;
+    std::memcpy(&out, &bits, sizeof out);
+    return out;
+}
+
 inline void CHECK_ENCODER (const Encoder& encoder) {
     if (!encoder)               throw std::runtime_error ("No valid encoder provided");
 }
@@ -852,51 +892,60 @@ inline Offset STORE_TILE_TABLE (const File& file, const Abstraction::TileTable& 
     if (table.layers.size() != table.extent.layers.size())
         throw std::runtime_error("Failure in tile ptr encoding; table does not match slide extent.");
     
-    uint32_t    n_layers    = U32_CAST(table.layers.size());
-    auto        __base      = file->ptr;
+    auto __base = file->ptr;
     // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     // SLIDE TILE ARRAY SERIALIZATION
     // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-    auto    tiles_size      = Serialization::SIZE_TILE_OFFSETS(table.layers);
-    Offset  tiles_offset    = offset.fetch_add(tiles_size);
-    __base                  = FILE_CHECK_EXPAND(file, offset); // Always check bounds before writing
-    Serialization::STORE_TILE_OFFSETS (__base, tiles_offset, table.layers);
+    // The generated API takes one flat entry array; flatten the per-layer
+    // tile lists into it.
+    std::vector<TileOffsetEntry> tile_entries;
+    for (auto&& layer : table.layers)
+        for (auto&& tile : layer)
+            tile_entries.push_back({tile.offset, tile.size});
+    auto   tiles_size   = size_of(TileOffsetsCreateInfo{tile_entries});
+    Offset tiles_offset = offset.fetch_add(tiles_size);
+    __base              = FILE_CHECK_EXPAND(file, offset); // Always check bounds before writing
+    THROW_IF_FAILED(store(__base, tiles_offset, TileOffsetsCreateInfo{tile_entries}), "STORE_TILE_OFFSETS");
     
     // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     // SLIDE TILE EXTENT SERIALIZATION
     // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     // Write Iris::Extent to file
     // This must be written backwards as an array of layer extents
-    auto   l_extents_size   = Serialization::SIZE_EXTENTS(table.extent.layers);
+    std::vector<LayerExtentEntry> extent_entries;
+    for (auto&& layer : table.extent.layers)
+        // Z_PLANES is the 1.1-appended field; zero = single plane, which is
+        // all this v1-era encoder knows how to express.
+        extent_entries.push_back({layer.xTiles, layer.yTiles, layer.scale, 0});
+    auto   l_extents_size = size_of(LayerExtentsCreateInfo{extent_entries});
     Offset l_extents_offset = offset.fetch_add(l_extents_size);
     __base                  = FILE_CHECK_EXPAND(file, offset);
-    Serialization::STORE_EXTENTS (__base, l_extents_offset, table.extent.layers);
+    THROW_IF_FAILED(store(__base, l_extents_offset, LayerExtentsCreateInfo{extent_entries}), "STORE_EXTENTS");
     
     // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     // WRITE THE TILE TABLE HEADER
     // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-    //
-    auto    ttable_size     = Serialization::TILE_TABLE::HEADER_SIZE;
+    auto    ttable_size     = TILE_TABLE::header_size;
     Offset  ttable_offset   = offset.fetch_add(ttable_size);
     __base                  = FILE_CHECK_EXPAND(file, offset);
-    Serialization::TileTableCreateInfo tile_table_create_info {
-        .tileTableOffset    = ttable_offset,
-        .encoding           = table.encoding,
-        .format             = table.format,
-        .tilesOffset        = tiles_offset,
-        .layerExtentsOffset = l_extents_offset,
-        .layers             = n_layers,
-        .widthPixels        = table.extent.width,
-        .heightPixels       = table.extent.height,
-    };
-    Serialization::STORE_TILE_TABLE (__base, tile_table_create_info);
+    THROW_IF_FAILED(store(__base, ttable_offset, TileTableCreateInfo {
+        .ENCODING            = static_cast<TileEncodings>(table.encoding),
+        .FORMAT              = static_cast<PixelFormats>(table.format),
+        .TILE_OFFSETS_OFFSET = tiles_offset,
+        .LAYER_EXTENTS_OFFSET = l_extents_offset,
+        .X_EXTENT            = table.extent.width,
+        .Y_EXTENT            = table.extent.height,
+        // TILE_LENGTH is the 1.1-appended field; the abstraction carries the
+        // slide's tile edge length (256 unless a file said otherwise).
+        .TILE_LENGTH         = table.tileLength,
+    }), "STORE_TILE_TABLE");
     
     // Return the Tile Table Offset
     return ttable_offset;
 }
 inline Offset RESERVE_METADATA (const File& file, atomic_uint64& offset)
 {
-    auto    metadata_size   = Serialization::METADATA::HEADER_SIZE;
+    auto    metadata_size   = METADATA::header_size;
     Offset  metadata_offset = offset.fetch_add(metadata_size);
     FILE_CHECK_EXPAND(file, offset);
     return  metadata_offset;
@@ -933,10 +982,14 @@ inline Offset STORE_ICC (const File& file,
     if (metadata.ICC_profile.size() == 0) return NULL_OFFSET;
     
     // Get bytes size and write ICC profile to byte stream
-    Size profile_size       = Serialization::SIZE_ICC_COLOR_PROFILE(metadata.ICC_profile);
+    Size profile_size       = size_of(IccProfileCreateInfo{
+        reinterpret_cast<const BYTE*>(metadata.ICC_profile.data()),
+        metadata.ICC_profile.size()});
     Offset profile_offset   = offset.fetch_add(profile_size);
     auto   __base           = FILE_CHECK_EXPAND(file, offset);
-    Serialization::STORE_ICC_COLOR_PROFILE(__base, profile_offset, metadata.ICC_profile);
+    THROW_IF_FAILED(store(__base, profile_offset, IccProfileCreateInfo{
+        reinterpret_cast<const BYTE*>(metadata.ICC_profile.data()),
+        metadata.ICC_profile.size()}), "STORE_ICC_COLOR_PROFILE");
     
     // Return the byte location of the ICC profile
     return profile_offset;
@@ -952,7 +1005,8 @@ inline Offset STORE_ASSOCIATED_IMAGES (const Context& ctx,
     if (metadata.associatedImages.size() == 0) return NULL_OFFSET;
     
     // Otherwise begin encoding images
-    Serialization::AssociatedImageCreateInfo associated_images;
+    // The array of associated image entries; one per label, filled below.
+    std::vector<ImageEntry> image_entries;
     
     // Encode each of the associated image variable byte blocks
     // This corresponds with IFE Specification Section 2.4.7
@@ -991,21 +1045,25 @@ inline Offset STORE_ASSOCIATED_IMAGES (const Context& ctx,
                 ("no bytes given for image buffer byte size");
             
             // Store the data-block 1) get size 2) write to the stream 3) record location
-            Size block_size         = Serialization::SIZE_IMAGES_BYTES({
-                .title              = label,
-                .dataBytes          = bytes->size()
-            });
+            // The generated store writes the block header only; the ASCII
+            // label and compressed stream follow it.
+            const Size block_size   = IMAGE_BYTES::header_size +
+                                      label.size() + bytes->size();
             Offset block_offset     = offset.fetch_add(block_size);
             auto   __base           = FILE_CHECK_EXPAND(file, offset);
-            Serialization::STORE_IMAGES_BYTES(__base, {
-                .offset             = block_offset,
-                .title              = label,
-                .data               = (BYTE*)bytes->data(),
-                .dataBytes          = bytes->size()
-            });
-            associated_images.images.push_back({
-                .offset             = block_offset,
-                .info               = info
+            THROW_IF_FAILED(store(__base, block_offset, ImageBytesCreateInfo{
+                U16_CAST(label.size()), U32_CAST(bytes->size())}), "STORE_IMAGES_BYTES");
+            BYTE* __ptr             = __base + block_offset + IMAGE_BYTES::header_size;
+            std::memcpy(__ptr, label.data(), label.size());
+            std::memcpy(__ptr + label.size(), (BYTE*)bytes->data(), bytes->size());
+            
+            image_entries.push_back({
+                block_offset,
+                info.width,
+                info.height,
+                static_cast<ImageEncodings>(info.encoding),
+                static_cast<PixelFormats>(info.sourceFormat),
+                HALF_TO_FLOAT(info.orientation)
             });
             
         } catch (std::runtime_error &error) {
@@ -1016,11 +1074,10 @@ inline Offset STORE_ASSOCIATED_IMAGES (const Context& ctx,
     }
     
     // Now record of all associated images to the byte stream
-    Size   images_size              = Serialization::SIZE_IMAGES_ARRAY(associated_images);
+    Size   images_size              = size_of(ImagesCreateInfo{image_entries});
     Offset images_offset            = offset.fetch_add(images_size);
-    associated_images.offset        = images_offset;
     auto   __base                   = FILE_CHECK_EXPAND(file, offset);
-    Serialization::STORE_IMAGES_ARRAY(__base, associated_images);
+    THROW_IF_FAILED(store(__base, images_offset, ImagesCreateInfo{image_entries}), "STORE_IMAGES_ARRAY");
     
     // Return the images array offset
     return images_offset;
@@ -1057,29 +1114,37 @@ inline Offset STORE_ATTRIBUTES (const File& file,
     // 2) Bytes
     // 3) Attributes header
     
+    // Build the attribute pairs once; the generated writer derives both the
+    // sizes array and the packed key/value byte run from them, so the
+    // slicing cannot drift from the bytes it describes.
+    std::vector<std::pair<std::string, std::string>> attr_pairs;
+    attr_pairs.reserve(attributes.size());
+    for (auto&& [key, value] : attributes)
+        attr_pairs.emplace_back(key, std::string(
+            reinterpret_cast<const char*>(value.data()), value.size()));
+    
     // Store the attributes sizes (how to slice up the char byte blob)
     // Sections 2.2.4
-    Size sizes_size     = Serialization::SIZE_ATTRIBUTES_SIZES(attributes);
+    Size sizes_size     = size_of(AttributeSizesCreateInfo{attr_pairs});
     Offset sizes_offset = offset.fetch_add(sizes_size);
     auto  __base        = FILE_CHECK_EXPAND(file, offset);
-    Serialization::STORE_ATTRIBUTES_SIZES(__base, sizes_offset, attributes);
+    THROW_IF_FAILED(store(__base, sizes_offset, AttributeSizesCreateInfo{attr_pairs}), "STORE_ATTRIBUTES_SIZES");
     
     // Store the raw attributes characters byte-blob
     // Section 2.2.5
-    Size bytes_size     = Serialization::SIZE_ATTRIBUTES_BYTES(attributes);
+    Size bytes_size     = size_of(AttributeBytesCreateInfo{attr_pairs});
     Offset bytes_offset = offset.fetch_add(bytes_size);
     __base              = FILE_CHECK_EXPAND(file, offset);
-    Serialization::STORE_ATTRIBUTES_BYTES(__base, bytes_offset, attributes);
+    THROW_IF_FAILED(store(__base, bytes_offset, AttributeBytesCreateInfo{attr_pairs}), "STORE_ATTRIBUTES_BYTES");
     
-    // Store the annotation header
-    Offset attr_offset  = offset.fetch_add(Serialization::ATTRIBUTES::HEADER_SIZE);
-    Serialization::STORE_ATTRIBUTES(__base, {
-        .attributesOffset   = attr_offset,
-        .type               = attributes.type,
-        .version            = attributes.version,
-        .sizes              = sizes_offset,
-        .bytes              = bytes_offset
-    });
+    // Store the attributes header
+    Offset attr_offset  = offset.fetch_add(ATTRIBUTES::header_size);
+    THROW_IF_FAILED(store(__base, attr_offset, AttributesCreateInfo{
+        .FORMAT       = static_cast<MetadataFormats>(attributes.type),
+        .VERSION      = attributes.version,
+        .SIZES_OFFSET = sizes_offset,
+        .BYTES_OFFSET = bytes_offset
+    }), "STORE_ATTRIBUTES");
     
     return attr_offset;
 }
@@ -1091,16 +1156,17 @@ inline void STORE_METADATA (const File& file,
                             const Offset attributes_offset,
                             const Offset annotations_offset)
 {
-    Serialization::STORE_METADATA(file->ptr, {
-        .metadataOffset     = metadata_offset,
-        .codecVersion       = metadata.codec,
-        .attributes         = attributes_offset,
-        .images             = images_offset,
-        .ICC_profile        = ICC_offset,
-        .annotations        = annotations_offset,
-        .micronsPerPixel    = metadata.micronsPerPixel,
-        .magnification      = metadata.magnification
-    });
+    THROW_IF_FAILED(store(file->ptr, metadata_offset, MetadataCreateInfo{
+        .CODEC_MAJOR        = U16_CAST(metadata.codec.major),
+        .CODEC_MINOR        = U16_CAST(metadata.codec.minor),
+        .CODEC_BUILD        = U16_CAST(metadata.codec.build),
+        .ATTRIBUTES_OFFSET  = attributes_offset,
+        .IMAGES_OFFSET      = images_offset,
+        .ICC_COLOR_OFFSET   = ICC_offset,
+        .ANNOTATIONS_OFFSET = annotations_offset,
+        .MICRONS_PIXEL      = metadata.micronsPerPixel,
+        .MAGNIFICATION      = metadata.magnification
+    }), "STORE_METADATA");
 }
 inline void STORE_FILE_HEADER (const File& file,
                                const Size file_size,
@@ -1110,12 +1176,15 @@ inline void STORE_FILE_HEADER (const File& file,
 {
     if (file->size < file_size) throw std::runtime_error
         ("[ERROR] File failed size check. Attempting to write header for truncated file.");
-    Serialization::STORE_FILE_HEADER(file->ptr, {
-        .fileSize           = file_size,
-        .revision           = revision,
-        .tileTableOffset    = tile_table_offset,
-        .metadataOffset     = metadata_offset
-    });
+    // EXTENSION_MAJOR/MINOR default to the schema version this build writes:
+    // the generated store always lays out the newest fields, so the file must
+    // claim the version its bytes actually have.
+    THROW_IF_FAILED(store(file->ptr, 0, FileHeaderCreateInfo{
+        .FILE_SIZE         = file_size,
+        .FILE_REVISION     = revision,
+        .TILE_TABLE_OFFSET = tile_table_offset,
+        .METADATA_OFFSET   = metadata_offset
+    }), "STORE_FILE_HEADER");
     resize_file(file, FileResizeInfo {
         .size               = file_size,
         .pageAlign          = false
@@ -1257,7 +1326,7 @@ Result __INTERNAL__Encoder::dispatch_encoder()
         }
         
         // Create the file byte offset tracker and reserve space for the footer
-        atomic_uint64 offset = Serialization::FILE_HEADER::HEADER_SIZE;
+        atomic_uint64 offset = FILE_HEADER::header_size;
         
         // Create the downsample information struct
         // WARNING: THIS MUST PERSIST UNTIL ALL ASYNC THREADS ARE COMPLETE

--- a/src/IrisCodecEncoder.cpp
+++ b/src/IrisCodecEncoder.cpp
@@ -1114,14 +1114,22 @@ inline Offset STORE_ATTRIBUTES (const File& file,
     // 2) Bytes
     // 3) Attributes header
     
-    // Build the attribute pairs once; the generated writer derives both the
-    // sizes array and the packed key/value byte run from them, so the
-    // slicing cannot drift from the bytes it describes.
-    std::vector<std::pair<std::string, std::string>> attr_pairs;
+    // Build the attributes once; the generated writer derives both the sizes
+    // array and the packed key/value byte run from them, so the slicing cannot
+    // drift from the bytes it describes.
+    //
+    // KIND defaults to ATTRIBUTE_STRING, so every value written here is text
+    // and the bytes are what this encoder has always produced. An attribute
+    // whose value is a DICOM sequence sets KIND to ATTRIBUTE_NESTED and fills
+    // `nested` with the offsets of the attributes blocks holding its items --
+    // which this encoder does not yet do, because nothing upstream of it
+    // carries a tree to write.
+    std::vector<AttributeSizeEntry> attr_pairs;
     attr_pairs.reserve(attributes.size());
     for (auto&& [key, value] : attributes)
-        attr_pairs.emplace_back(key, std::string(
-            reinterpret_cast<const char*>(value.data()), value.size()));
+        attr_pairs.push_back({.key   = key,
+                              .value = std::string(
+                                  reinterpret_cast<const char*>(value.data()), value.size())});
     
     // Store the attributes sizes (how to slice up the char byte blob)
     // Sections 2.2.4

--- a/src/IrisCodecPriv.hpp
+++ b/src/IrisCodecPriv.hpp
@@ -44,7 +44,7 @@
 #include "IrisBuffer.hpp"
 #include "IrisQueue.hpp"
 #include "IrisAsync.hpp"
-#include "IrisCodecExtension.hpp"
+#include "IrisFileExtension.hpp"
 #include "IrisCodecPrivTypes.hpp"
 #include "IrisCodecFile.hpp"
 #include "IrisCodecContext.hpp"

--- a/src/IrisCodecSlide.cpp
+++ b/src/IrisCodecSlide.cpp
@@ -30,7 +30,11 @@ Iris::Result is_iris_codec_file(const std::string &file_path) noexcept
         if (file == nullptr) throw std::runtime_error
             ("file path is not a valid file\n");
         
-        if (is_Iris_Codec_file(file->ptr, file->size) == false)
+        // Compared against IRIS_SUCCESS rather than tested for truth: the IFE
+        // entry point returns a Result now, and Iris::Result::operator bool is
+        // non-const, so the flag comparison is the form that keeps working if
+        // this is ever held in a const local.
+        if (is_iris_codec_file({file->ptr, file->size}) != IRIS_SUCCESS)
             throw std::runtime_error
             ("file does not contain an Iris Codec Extension header.\n");
         
@@ -55,7 +59,7 @@ Iris::Result validate_slide (const struct SlideOpenInfo &info) noexcept
         if (file == nullptr) throw std::runtime_error("file path is not a valid file\n");
         
         ReadLock read_lock (file->resize);
-        return validate_file_structure(file->ptr, file->size);
+        return validate_file_structure({file->ptr, file->size});
         
     } catch (std::runtime_error &e) {
         return Iris::Result (
@@ -209,7 +213,7 @@ Iris::Result get_slide_annotations(const Slide &slide, Annotations &annotations)
 __INTERNAL__Slide::__INTERNAL__Slide    (const Context& cxt, const File& file) :
 _context                                (cxt),
 _file                                   (file),
-_abstraction                            (abstract_file_structure(file->ptr, file->size))
+_abstraction                            (abstract_file_structure({file->ptr, file->size}))
 {
     
 }


### PR DESCRIPTION
Switch the build and private includes to the new Iris File Extension header layout, including the generated_source directory needed by the public umbrella headers. The encoder and JS bindings are updated to use the generated serialization API naming and store/size_of helpers, with the necessary data reshaping and metadata field mapping to keep file writing compatible with the newer schema.